### PR TITLE
fix(admin): centralise BrowserStrapi type used by window.strapi

### DIFF
--- a/packages/admin-test-utils/custom.d.ts
+++ b/packages/admin-test-utils/custom.d.ts
@@ -1,23 +1,7 @@
-export {};
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 declare global {
   interface Window {
-    strapi: {
-      backendURL: string;
-      isEE: boolean;
-      features: {
-        SSO: 'sso';
-        isEnabled: (featureName?: string) => boolean;
-      };
-      future: {
-        isEnabled: (name: string) => boolean;
-      };
-      projectType: string;
-      telemetryDisabled: boolean;
-      flags: {
-        nps: boolean;
-        promoteEE: boolean;
-      };
-    };
+    strapi: BrowserStrapi;
   }
 }

--- a/packages/admin-test-utils/src/setup.ts
+++ b/packages/admin-test-utils/src/setup.ts
@@ -1,5 +1,6 @@
 import { format } from 'util';
 import { ResizeObserver } from '@juggle/resize-observer';
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 /* -------------------------------------------------------------------------------------------------
  * IntersectionObserver
@@ -108,11 +109,18 @@ globalThis.console = patchedConsole as any;
  * Strapi
  * -----------------------------------------------------------------------------------------------*/
 
-window.strapi = {
+const browserStrapi: BrowserStrapi = {
   backendURL: 'http://localhost:1337',
   isEE: false,
+  isTrial: false,
+  isTrialLicense: false,
+  ai: {
+    enabled: false,
+  },
   features: {
     SSO: 'sso',
+    REVIEW_WORKFLOWS: 'review-workflows',
+    AUDIT_LOGS: 'audit-logs',
     isEnabled: () => false,
   },
   future: {
@@ -125,6 +133,10 @@ window.strapi = {
     promoteEE: true,
   },
 };
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - conflicting node Strapi with window BrowserStrapi
+window.strapi = browserStrapi;
 
 /* -------------------------------------------------------------------------------------------------
  * matchMedia

--- a/packages/core/admin/admin/custom.d.ts
+++ b/packages/core/admin/admin/custom.d.ts
@@ -2,34 +2,10 @@
 
 import { type StrapiTheme } from '@strapi/design-system';
 
-import type { Modules } from '@strapi/types';
+import type { BrowserStrapi } from './src/types/browserStrapi';
 
 declare module 'styled-components' {
   export interface DefaultTheme extends StrapiTheme {}
-}
-
-interface BrowserStrapi {
-  backendURL: string;
-  isEE: boolean;
-  future: {
-    isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
-  };
-  features: {
-    SSO: 'sso';
-    AUDIT_LOGS: 'audit-logs';
-    REVIEW_WORKFLOWS: 'review-workflows';
-    isEnabled: (featureName?: string) => boolean;
-  };
-  isTrialLicense: boolean;
-  flags: {
-    promoteEE?: boolean;
-    nps?: boolean;
-  };
-  projectType: 'Community' | 'Enterprise';
-  telemetryDisabled: boolean;
-  ai: {
-    enabled: boolean;
-  };
 }
 
 declare global {

--- a/packages/core/admin/admin/custom.d.ts
+++ b/packages/core/admin/admin/custom.d.ts
@@ -10,6 +10,6 @@ declare module 'styled-components' {
 
 declare global {
   interface Window {
-    strapi: BrowserStrapi;
+    strapi?: BrowserStrapi;
   }
 }

--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -104,6 +104,7 @@ export * from './utils/rulesEngine';
 export * from './utils/users';
 export * from './services/api';
 export type { CMAdminConfiguration } from './types/adminConfiguration';
+export type { BrowserStrapi } from './types/browserStrapi';
 
 /**
  * Components

--- a/packages/core/admin/admin/src/render.ts
+++ b/packages/core/admin/admin/src/render.ts
@@ -69,7 +69,7 @@ const renderAdmin = async (
 
   const { get } = getFetchClient();
 
-  interface ProjectType extends Pick<Window['strapi'], 'flags'> {
+  interface ProjectType extends Pick<BrowserStrapi, 'flags'> {
     isEE: boolean;
     isTrial: boolean;
     features: {
@@ -107,6 +107,8 @@ const renderAdmin = async (
     console.error(err);
   }
 
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - conflicting node Strapi with window BrowserStrapi
   window.strapi = browserStrapi;
 
   const app = new StrapiApp({

--- a/packages/core/admin/admin/src/render.ts
+++ b/packages/core/admin/admin/src/render.ts
@@ -5,6 +5,7 @@ import { StrapiApp, StrapiAppConstructorArgs } from './StrapiApp';
 import { getFetchClient } from './utils/getFetchClient';
 import { createAbsoluteUrl } from './utils/urls';
 
+import type { BrowserStrapi } from './types/browserStrapi';
 import type { Modules } from '@strapi/types';
 
 interface RenderAdminArgs {
@@ -25,7 +26,7 @@ const renderAdmin = async (
     throw new Error('[@strapi/admin]: Could not find the root element to mount the admin app');
   }
 
-  window.strapi = {
+  const browserStrapi: BrowserStrapi = {
     /**
      * This ENV variable is passed from the strapi instance, by default no url is set
      * in the config and therefore the instance returns you an empty string so URLs are relative.
@@ -35,6 +36,7 @@ const renderAdmin = async (
     backendURL: createAbsoluteUrl(process.env.STRAPI_ADMIN_BACKEND_URL),
     isEE: false,
     isTrial: false,
+    isTrialLicense: false,
     telemetryDisabled: process.env.STRAPI_TELEMETRY_DISABLED === 'true',
     future: {
       isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => {
@@ -85,18 +87,18 @@ const renderAdmin = async (
       },
     } = await get<{ data: ProjectType }>('/admin/project-type');
 
-    window.strapi.isEE = isEE;
-    window.strapi.isTrialLicense = isTrial;
-    window.strapi.flags = flags;
-    window.strapi.features = {
-      ...window.strapi.features,
+    browserStrapi.isEE = isEE;
+    browserStrapi.isTrialLicense = isTrial;
+    browserStrapi.flags = flags;
+    browserStrapi.features = {
+      ...browserStrapi.features,
       isEnabled: (featureName: string | undefined) =>
         features.some((feature) => feature.name === featureName),
     };
-    window.strapi.projectType = isEE ? 'Enterprise' : 'Community';
+    browserStrapi.projectType = isEE ? 'Enterprise' : 'Community';
     // eslint-disable-next-line
     // @ts-ignore – there's pollution from the global scope of Node. Cannot use @ts-expect-error because of build:code and build:types context collision.
-    window.strapi.ai = ai;
+    browserStrapi.ai = ai;
   } catch (err) {
     /**
      * If this fails, we simply don't activate any EE features.
@@ -104,6 +106,8 @@ const renderAdmin = async (
      */
     console.error(err);
   }
+
+  window.strapi = browserStrapi;
 
   const app = new StrapiApp({
     config: customisations?.config,

--- a/packages/core/admin/admin/src/tests/adminTokensFutureFlag.test.ts
+++ b/packages/core/admin/admin/src/tests/adminTokensFutureFlag.test.ts
@@ -1,14 +1,19 @@
 import { SETTINGS_LINKS_CE } from '../constants';
 import { ROUTES_CE } from '../pages/Settings/constants';
 
-declare global {
-  interface Window {
-    strapi: any;
-  }
-}
+import type { BrowserStrapi } from '../types/browserStrapi';
 
 const setWindowStrapi = (adminTokensEnabled: boolean) => {
-  window.strapi = {
+  const browserStrapi: BrowserStrapi = {
+    isTrial: false,
+    isTrialLicense: false,
+    backendURL: '',
+    isEE: false,
+    telemetryDisabled: false,
+    projectType: 'Community',
+    ai: {
+      enabled: false,
+    },
     future: {
       isEnabled: jest.fn((featureName: string) => {
         return featureName === 'adminTokens' ? adminTokensEnabled : false;
@@ -18,15 +23,21 @@ const setWindowStrapi = (adminTokensEnabled: boolean) => {
       SSO: 'sso',
       AUDIT_LOGS: 'audit-logs',
       isEnabled: jest.fn(() => false),
+      REVIEW_WORKFLOWS: 'review-workflows',
     },
     flags: {
       promoteEE: false,
     },
   };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - conflicting node Strapi with window BrowserStrapi
+  window.strapi = browserStrapi;
 };
 
 describe('adminTokens future flag', () => {
   afterEach(() => {
+    // @ts-expect-error - window.strapi is not optional
     delete window.strapi;
   });
 

--- a/packages/core/admin/admin/src/types/browserStrapi.ts
+++ b/packages/core/admin/admin/src/types/browserStrapi.ts
@@ -1,0 +1,26 @@
+import type { Modules } from '@strapi/types';
+
+export interface BrowserStrapi {
+  backendURL: string;
+  isEE: boolean;
+  isTrial: boolean;
+  future: {
+    isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
+  };
+  features: {
+    SSO: 'sso';
+    AUDIT_LOGS: 'audit-logs';
+    REVIEW_WORKFLOWS: 'review-workflows';
+    isEnabled: (featureName?: string) => boolean;
+  };
+  isTrialLicense: boolean;
+  flags: {
+    promoteEE?: boolean;
+    nps?: boolean;
+  };
+  projectType: 'Community' | 'Enterprise';
+  telemetryDisabled: boolean;
+  ai: {
+    enabled: boolean;
+  };
+}

--- a/packages/core/admin/ee/admin/custom.d.ts
+++ b/packages/core/admin/ee/admin/custom.d.ts
@@ -2,7 +2,7 @@
 
 import { type StrapiTheme } from '@strapi/design-system';
 
-import type { Modules } from '@strapi/types';
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 declare module 'styled-components' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -11,27 +11,6 @@ declare module 'styled-components' {
 
 declare global {
   interface Window {
-    strapi: {
-      backendURL: string;
-      isEE: boolean;
-      future: {
-        isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
-      };
-      features: {
-        SSO: 'sso';
-        AUDIT_LOGS: 'audit-logs';
-        REVIEW_WORKFLOWS: 'review-workflows';
-        isEnabled: (featureName?: string) => boolean;
-      };
-      flags: {
-        promoteEE?: boolean;
-        nps?: boolean;
-      };
-      projectType: 'Community' | 'Enterprise';
-      telemetryDisabled: boolean;
-      ai: {
-        enabled: boolean;
-      };
-    };
+    strapi: BrowserStrapi;
   }
 }

--- a/packages/core/content-manager/admin/custom.d.ts
+++ b/packages/core/content-manager/admin/custom.d.ts
@@ -6,7 +6,8 @@ import { type HistoryEditor } from 'slate-history';
 import { type ReactEditor } from 'slate-react';
 
 import type { LinkEditor } from './src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Link';
-import type { Schema, Modules } from '@strapi/types';
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
+import type { Schema } from '@strapi/types';
 
 declare module 'styled-components' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -22,27 +23,6 @@ declare module 'slate' {
     Descendant: Schema.Attribute.BlocksInlineNode | Text;
     Text: Schema.Attribute.BlocksTextNode;
   }
-}
-
-interface BrowserStrapi {
-  backendURL: string;
-  isEE: boolean;
-  future: {
-    isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
-  };
-  features: {
-    SSO: 'sso';
-    AUDIT_LOGS: 'audit-logs';
-    REVIEW_WORKFLOWS: 'review-workflows';
-    isEnabled: (featureName?: string) => boolean;
-  };
-  isTrial: boolean;
-  flags: {
-    promoteEE?: boolean;
-    nps?: boolean;
-  };
-  projectType: 'Community' | 'Enterprise';
-  telemetryDisabled: boolean;
 }
 
 declare global {

--- a/packages/core/content-releases/admin/custom.d.ts
+++ b/packages/core/content-releases/admin/custom.d.ts
@@ -1,27 +1,9 @@
 /// <reference types="vite/client" />
 
-export {};
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 declare global {
   interface Window {
-    strapi: {
-      backendURL: string;
-      isEE: boolean;
-      features: {
-        SSO: 'sso';
-        AUDIT_LOGS: 'audit-logs';
-        REVIEW_WORKFLOWS: 'review-workflows';
-        isEnabled: (featureName?: string) => boolean;
-      };
-      future: {
-        isEnabled: (name: string) => boolean;
-      };
-      flags: {
-        nps?: boolean;
-        promoteEE?: boolean;
-      };
-      projectType: 'Community' | 'Enterprise';
-      telemetryDisabled: boolean;
-    };
+    strapi: BrowserStrapi;
   }
 }

--- a/packages/core/review-workflows/admin/custom.d.ts
+++ b/packages/core/review-workflows/admin/custom.d.ts
@@ -2,34 +2,12 @@
 
 import { type StrapiTheme } from '@strapi/design-system';
 
-import type { Modules } from '@strapi/types';
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 declare module 'styled-components' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface DefaultTheme extends StrapiTheme {}
 }
-
-interface BrowserStrapi {
-  backendURL: string;
-  isEE: boolean;
-  future: {
-    isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
-  };
-  features: {
-    SSO: 'sso';
-    AUDIT_LOGS: 'audit-logs';
-    REVIEW_WORKFLOWS: 'review-workflows';
-    isEnabled: (featureName?: string) => boolean;
-  };
-  isTrial: boolean;
-  flags: {
-    promoteEE?: boolean;
-    nps?: boolean;
-  };
-  projectType: 'Community' | 'Enterprise';
-  telemetryDisabled: boolean;
-}
-
 declare global {
   interface Window {
     strapi: BrowserStrapi;

--- a/packages/core/upload/admin/custom.d.ts
+++ b/packages/core/upload/admin/custom.d.ts
@@ -1,13 +1,8 @@
-export {};
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 declare global {
   interface Window {
-    strapi: {
-      backendURL: string;
-      future: {
-        isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
-      };
-    };
+    strapi: BrowserStrapi;
   }
   declare module '*?raw';
 }

--- a/packages/plugins/cloud/admin/global.d.ts
+++ b/packages/plugins/cloud/admin/global.d.ts
@@ -1,9 +1,7 @@
-export {};
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 declare global {
   interface Window {
-    strapi: {
-      backendURL: string;
-    };
+    strapi: BrowserStrapi;
   }
 }

--- a/packages/plugins/documentation/admin/src/global.d.ts
+++ b/packages/plugins/documentation/admin/src/global.d.ts
@@ -1,25 +1,7 @@
-export {};
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 declare global {
   interface Window {
-    strapi: {
-      backendURL: string;
-      isEE: boolean;
-      features: {
-        SSO: 'sso';
-        AUDIT_LOGS: 'audit-logs';
-        REVIEW_WORKFLOWS: 'review-workflows';
-        isEnabled: (featureName?: string) => boolean;
-      };
-      future: {
-        isEnabled: (name: string) => boolean;
-      };
-      flags: {
-        nps?: boolean;
-        promoteEE?: boolean;
-      };
-      projectType: 'Community' | 'Enterprise';
-      telemetryDisabled: boolean;
-    };
+    strapi: BrowserStrapi;
   }
 }

--- a/packages/plugins/i18n/admin/custom.d.ts
+++ b/packages/plugins/i18n/admin/custom.d.ts
@@ -2,34 +2,10 @@
 
 import { type StrapiTheme } from '@strapi/design-system';
 
-import type { Modules } from '@strapi/types';
+import type { BrowserStrapi } from '@strapi/admin/strapi-admin';
 
 declare module 'styled-components' {
   export interface DefaultTheme extends StrapiTheme {}
-}
-
-interface BrowserStrapi {
-  backendURL: string;
-  isEE: boolean;
-  future: {
-    isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
-  };
-  features: {
-    SSO: 'sso';
-    AUDIT_LOGS: 'audit-logs';
-    REVIEW_WORKFLOWS: 'review-workflows';
-    isEnabled: (featureName?: string) => boolean;
-  };
-  isTrialLicense: boolean;
-  flags: {
-    promoteEE?: boolean;
-    nps?: boolean;
-  };
-  projectType: 'Community' | 'Enterprise';
-  telemetryDisabled: boolean;
-  ai: {
-    enabled: boolean;
-  };
 }
 
 declare global {


### PR DESCRIPTION
### What does it do?

- Moves the `BrowserStrapi` interface out of `packages/core/admin/admin/custom.d.ts` (a declaration file skipped under `skipLibCheck`) and into a real `.ts` module at `packages/core/admin/admin/src/types/browserStrapi.ts`, then re-exports it from `@strapi/admin/strapi-admin`.
- Updates `custom.d.ts` / `global.d.ts` in `admin`, `ee admin`, `content-manager`, `content-releases`, `review-workflows`, `upload`, `cloud`, `documentation`, `i18n`, and `admin-test-utils` to consume that single shared type instead of redeclaring divergent inline shapes for `window.strapi`.
- Updates `admin-test-utils/src/setup.ts` and `admin/src/tests/adminTokensFutureFlag.test.ts` to build a typed `BrowserStrapi` value, fixing fields that had drifted (`isTrial`, `isTrialLicense`, `ai`, `REVIEW_WORKFLOWS`, `AUDIT_LOGS`).
- Marks `window.strapi` as optional in `admin/custom.d.ts` so tests can `delete window.strapi` between cases, and isolates the existing node-vs-browser `Strapi` global collision behind localised `@ts-ignore` lines at the assignment sites.

### Why is it needed?

`skipLibCheck` makes TypeScript skip declaration files, so the `BrowserStrapi` interface that lived in `custom.d.ts` was never compared against the actual `window.strapi` assignments. The shape silently drifted between packages — multiple packages had their own copy with different fields (some missing `isTrial`, some missing `ai`, some missing `REVIEW_WORKFLOWS`/`AUDIT_LOGS`) — and the test/setup utilities built `window.strapi` objects that no longer matched what the runtime expected.

Centralising the type in a regular module:

- gives every consumer a single source of truth for the `window.strapi` contract,
- lets the compiler catch drift the next time the shape changes,
- removes ~120 lines of duplicated interface declarations.

### How to test it?

- `pnpm install`
- `pnpm nx run-many -t lint -p @strapi/admin-test-utils,@strapi/admin,@strapi/content-manager,@strapi/content-releases,@strapi/review-workflows,@strapi/upload,@strapi/plugin-cloud,@strapi/plugin-documentation,@strapi/i18n` — should pass.
- `pnpm nx run-many -t test:ts:front -p @strapi/admin,@strapi/content-manager,@strapi/content-releases,@strapi/review-workflows,@strapi/upload,@strapi/i18n` — type-check the admin/front bundles to confirm `BrowserStrapi` resolves through the new re-export.
- `pnpm nx run @strapi/admin:test:front` — exercises `adminTokensFutureFlag.test.ts`, which now constructs a typed `BrowserStrapi`.
- Boot a fresh dev project (`yarn create strapi-app`) against this branch and confirm the admin still loads and `window.strapi` reflects the EE/CE flags as before — the runtime shape is unchanged, only the type plumbing moved.

### Related issue(s)/PR(s)

None.